### PR TITLE
yf: remove processing bill status

### DIFF
--- a/src/interfaces/bill.ts
+++ b/src/interfaces/bill.ts
@@ -16,7 +16,6 @@ export enum BillType {
 
 export enum BillStatus {
   PENDING = 'PENDING',
-  PROCESSING_PAYMENT = 'PROCESSING_PAYMENT',
   PAID = 'PAID'
 }
 


### PR DESCRIPTION
We no longer need the `PROCESSING_PAYMENT` status for Bills.