### PR TITLE
chore: add creation timestamp to lease agreements

### DIFF
--- a/src/interfaces/lease.ts
+++ b/src/interfaces/lease.ts
@@ -60,6 +60,7 @@ export interface ILeaseAgreement {
   occupants: IOccupant[];
   changeRequests: ILeaseChangeRequest[];
   source: LeaseAgreementSource;
+  timestamp: number;
 }
 export type IdLeaseAgreement = IEntity & ILeaseAgreement;
 


### PR DESCRIPTION
Adding timestamp when we create a lease agreement so we can order by this field if we need to.