### PR TITLE
Fix: changed spelling of lease agreement status from 'canceled' to 'cancelled'

### DIFF
--- a/src/enums/lease.ts
+++ b/src/enums/lease.ts
@@ -14,7 +14,7 @@ export enum LeaseAgreementStatus {
   DRAFT = 'draft',
   PENDING_TENANT_SIGNATURE = 'pending-tenant-signature',
   SIGNED = 'signed',
-  CANCELED = 'canceled',
+  CANCELLED = 'cancelled',
   TERMINATED = 'Terminated',
 }
 


### PR DESCRIPTION
Changed spelling of lease agreement status from 'canceled' to 'cancelled'.